### PR TITLE
Use `guzzle/guzzle` package instead of `guzzlehttp/guzzle`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,10 @@
     },
     "autoload": {
         "psr-4": { "Delighted\\": "lib/Delighted/" }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "homepage": "http://github.com/delighted/delighted-php",
     "require": {
-        "guzzlehttp/guzzle": "~3.8",
+        "guzzle/guzzle": "~3.8",
         "php": ">= 5.3.3"
     },
     "authors": [


### PR DESCRIPTION
Hi! 

I had to fight some dependency hell recently :)
The problem was with guzzle dependency version conflict.

This _Delighed_ lib requires `guzzlehttp/guzzle` v3.x, while most of other libs require `guzzlehttp/guzzle` v4.x and up.

It can be fixed by switching dependency to legacy `guzzle/guzzle` package (which is left for outdated libraries). As Guzzle switched to another root namespace (`GuzzleHttp`) since v4 we can have `guzzle/guzzle` at 3.x and `guzzlehttp/guzzle` 4.x+ at the same time in a single project, which fixes conflict.

Also Guzzle team explicitly recommends to use `guzzle/guzzle` for pre-4 versions dependencies. See https://github.com/guzzle/guzzle#version-guidance

Also I've added "version-alias" section which allows to use dev-master for `~1.0` requirement.
