### PR TITLE
Restricted Guzzle version to 3.8.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "homepage": "http://github.com/delighted/delighted-php",
     "require": {
-        "guzzle/guzzle": "~3.8",
+        "guzzle/guzzle": "~3.8.0",
         "php": ">= 5.3.3"
     },
     "authors": [


### PR DESCRIPTION
At least test suite is incompatible with 3.9.*
