### PR TITLE
Pins HHVM to 3.30

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
+  - hhvm-3.30
 
 script: ./run-tests.php


### PR DESCRIPTION
HHVM announced that it was dropping PHP support in HHVM 4. See
https://hhvm.com/blog/2018/09/12/end-of-php-support-future-of-hack.html
Given this direction, the HHVM version should be pinned to the last
fully supported version.