### PR TITLE
Update supported runtimes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: php
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
   - 7.1
-  - hhvm
+  - 7.2
+  - 7.3
 
 script: ./run-tests.php

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Official PHP client for the [Delighted API](https://delighted.com/docs/api).
 
 ## Requirements
 
-- PHP 5.5 or greater
+- PHP 7.1 or greater
 - The [Composer](http://getcomposer.org/) package manager
 - A [Delighted API](https://delighted.com/docs/api) key
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "guzzlehttp/guzzle": "^6.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5",
+        "phpunit/phpunit": "~7.0",
         "symfony/var-dumper": "^3.2"
     },
     "autoload": {

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -6,9 +6,8 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use PHPUnit_Framework_TestCase;
 
-class TestCase extends PHPUnit_Framework_TestCase
+class TestCase extends \PHPUnit\Framework\TestCase
 {
     /** @var TestClient */
     protected $client;
@@ -19,17 +18,15 @@ class TestCase extends PHPUnit_Framework_TestCase
     /** @var \GuzzleHttp\Handler\MockHandler */
     protected static $mock_handler;
 
-    public function __construct($opts = [])
+    public function setUp() {
+        $this->client = TestClient::getInstance(['apiKey' => 'abc123', 'handler' => self::$mock_stack]);
+    }
+
+    public static function setUpBeforeClass()
     {
         if (! self::$mock_stack) {
             self::$mock_stack = HandlerStack::create(new MockHandler());
         }
-        $this->client = TestClient::getInstance(['apiKey' => 'abc123', 'handler' => self::$mock_stack]);
-    }
-
-    protected function setUp()
-    {
-
     }
 
     protected function assertObjectPropertyIs($value, $object, $property)


### PR DESCRIPTION
PHP 7.0 along with 5.5 and 5.6 reached end of life and are [no longer actively supported](https://www.php.net/supported-versions.php). HHVM also [announced](https://hhvm.com/blog/2018/09/12/end-of-php-support-future-of-hack.html) its end of support for PHP 7. This sets a new baseline of PHP 7.1, 7.2, and 7.3.