### PR TITLE
Allow guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^6.2|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.0",


### PR DESCRIPTION
Hey, thanks so much for this package! We're working up upgrading to Laravel 8 which requires Guzzle 7. I did a quick check against the upgrade guide [here](https://github.com/guzzle/guzzle/blob/master/UPGRADING.md#60-to-70) and everything appears to be compatible.