### PR TITLE
Fix for jsonSerialize signature change deprecation warning in PHP 8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.1 (2023-12-14)
+
+- Add `ReturnTypeWillChange` attribute on Resource->jsonSerialize()
+
 ## 4.1.0 (2021-05-12)
 
 - Add support for Autopilot API

--- a/lib/Delighted/Resource.php
+++ b/lib/Delighted/Resource.php
@@ -65,6 +65,7 @@ class Resource implements JSONSerializable
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = $this->__data;

--- a/lib/Delighted/Version.php
+++ b/lib/Delighted/Version.php
@@ -2,4 +2,4 @@
 
 namespace Delighted;
 
-const VERSION = '4.1.0';
+const VERSION = '4.1.1';


### PR DESCRIPTION
Fixes #29 

As this will be interpreted as a comment in previous versions of PHP, this should be safe.